### PR TITLE
feat: support the newly-GA AWS SDK for Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,7 +70,7 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.67
+      - uses: dtolnay/rust-toolchain@1.68
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       - run: cargo nextest run --workspace --no-fail-fast --features derive,once_cell --run-ignored all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format of this changelog is based on [Keep a Changelog](https://keepachangel
 
 ## [Unreleased]
 
+_Note_: Due to the updated MSRV of the AWS SDK, Modyne has updated its MSRV to 1.68.0
+
+- BREAKING: Updated the AWS SDK to 1.0 ([#13])
+
+[#13](https://github.com/neoeinstein/modyne/issues/13)
+
 ## [0.2.1] - 2023-11-15
 
 - Fix: Correctly handle `KeyCondition`s that don't specify a sort key ([#9])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,13 @@ once_cell = ["dep:once_cell"]
 [dependencies]
 aliri_braid = "0.4.0"
 async-trait = "0.1.66"
-aws-config = "0.56.1"
-aws-sdk-dynamodb = "0.30.0"
+aws-config = "1.0.1"
+aws-sdk-dynamodb = "1.3.0"
 fnv = "1.0.7"
 modyne-derive = { version = "=0.2.1", optional = true, path = "./modyne-derive" }
 once_cell = { version = "1.17.2", optional = true }
 serde = { version = "1.0.158", features = ["derive"] }
-serde_dynamo = { version = "4.2.5", features = ["aws-sdk-dynamodb+0_30"] }
+serde_dynamo = { version = "4.2.13", features = ["aws-sdk-dynamodb+1"] }
 thiserror = "1.0.38"
 time = { version = "0.3.20", features = ["formatting", "parsing", "serde"] }
 tokio = { version = "1.0", features = ["sync"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.67.0"
+rust-version = "1.68.0"
 include = [
     "/docs",
     "/src",

--- a/README.md
+++ b/README.md
@@ -52,34 +52,6 @@ single-table design.
 For a more complete tour of the functionality in this crate, see the
 [documentation on docs.rs][docsrs].
 
-## Usage notes
-
-While _modyne_ is available and ready for general use, you should be aware of a
-few usage notes before you commit to this crate.
-
-### Undocumented field usage
-
-This library relies on the undocumented ability to directly access the `item`
-field on response objects returned by the DynamoDB API. It does this because the
-deserializer in `serde_dynamo` requires ownership of the items map. Without
-directly accessing the field, every attempt to deserialize would require cloning
-the entire items map every time, which would be undesirable and cause
-significant performance overhead. In the event that this field becomes
-unavailable, we may need to fall back to this less-performant mechanism.
-
-### Binding to latest AWS SDK
-
-As of now, this library will only bind itself to the latest version of the AWS
-DynamoDB SDK. This may be updated in the future to use feature flags to allow
-targeting multiple different SDK versions, but as this crate gets going we will
-only target a single version of the AWS SDK, most often the latest version.
-
-An update to the AWS SDK that does not break _modyne_'s usage of the AWS SDK
-will only result in a minor version bump. If the AWS SDK exposes an observable
-breaking change to _modyne_, then a major version bump will be used. Prior to
-1.0, those bumps will be to the patch and minor version components,
-respectively.
-
 ---
 
 †: The MSRV for this crate can be lowered to 1.68.0 by enabling the

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ respectively.
 
 ---
 
-†: The MSRV for this crate can be lowered to 1.67.0 by enabling the
+†: The MSRV for this crate can be lowered to 1.68.0 by enabling the
 `once_cell` feature.
 
 [cratesio]: https://crates.io/crates/modyne

--- a/docs/modyne.md
+++ b/docs/modyne.md
@@ -381,5 +381,5 @@ impl Database {
 ## Minimum supported Rust version (MSRV)
 
 The minimum supported Rust version for this crate is 1.70.0. The MSRV can be
-reduced to 1.67.0 by enabling the `once_cell` feature to use that crate's lazy
+reduced to 1.68.0 by enabling the `once_cell` feature to use that crate's lazy
 initialization primitives if desired.

--- a/dynamodb-book/ch18-sessionstore/Cargo.toml
+++ b/dynamodb-book/ch18-sessionstore/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/dynamodb-book-ch18-sessionstore"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
-rust-version = "1.67.0"
+rust-version = "1.68.0"
 
 [features]
 default = []

--- a/dynamodb-book/ch18-sessionstore/Cargo.toml
+++ b/dynamodb-book/ch18-sessionstore/Cargo.toml
@@ -18,7 +18,7 @@ once_cell = ["modyne/once_cell"]
 
 [dependencies]
 aliri_braid = "0.4.0"
-aws-sdk-dynamodb = "0.30.0"
+aws-sdk-dynamodb = "1.3.0"
 modyne = { version = "0.2.1", path = "../..", features = ["derive"] }
 serde = { version = "1.0.158", features = ["derive"] }
 time = { version = "0.3.20", features = ["formatting", "parsing", "serde"] }
@@ -27,8 +27,8 @@ tracing = "0.1.36"
 uuid = { version = "1.3.0", features = ["v4", "serde"] }
 
 [dev-dependencies]
-aws-config = "0.56.1"
-aws-credential-types = "0.56.1"
+aws-config = "1.0.1"
+aws-credential-types = "1.0.1"
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
 tokio = { version = "1.0", features = ["macros"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/dynamodb-book/ch18-sessionstore/tests/localstack.rs
+++ b/dynamodb-book/ch18-sessionstore/tests/localstack.rs
@@ -11,7 +11,7 @@ use modyne::{
 #[ignore = "this test requires a local DynamoDB instance running on localhost:4566 and may be \
             slow"]
 async fn localstack_only_test() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let config = aws_config::from_env()
+    let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
         .endpoint_url("http://localhost:4566")
         .credentials_provider(aws_credential_types::Credentials::new(
             "test", "test", None, None, "static",
@@ -32,7 +32,7 @@ async fn localstack_only_test() -> Result<(), Box<dyn std::error::Error + Send +
             TimeToLiveSpecification::builder()
                 .attribute_name("ttl")
                 .enabled(true)
-                .build(),
+                .build()?,
         )
         .send()
         .await?;
@@ -88,7 +88,7 @@ async fn localstack_only_test() -> Result<(), Box<dyn std::error::Error + Send +
 #[ignore = "this test requires a local DynamoDB instance running on localhost:4566 and may be \
             slow"]
 async fn batch_put_get_delete() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let config = aws_config::from_env()
+    let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
         .endpoint_url("http://localhost:4566")
         .credentials_provider(aws_credential_types::Credentials::new(
             "test", "test", None, None, "static",
@@ -109,7 +109,7 @@ async fn batch_put_get_delete() -> Result<(), Box<dyn std::error::Error + Send +
             TimeToLiveSpecification::builder()
                 .attribute_name("ttl")
                 .enabled(true)
-                .build(),
+                .build()?,
         )
         .send()
         .await?;

--- a/dynamodb-book/ch19-ecomm/Cargo.toml
+++ b/dynamodb-book/ch19-ecomm/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/dynamodb-book-ch19-ecomm"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
-rust-version = "1.67.0"
+rust-version = "1.68.0"
 
 [features]
 default = []

--- a/dynamodb-book/ch19-ecomm/Cargo.toml
+++ b/dynamodb-book/ch19-ecomm/Cargo.toml
@@ -18,7 +18,7 @@ once_cell = ["modyne/once_cell"]
 
 [dependencies]
 aliri_braid = "0.4.0"
-aws-sdk-dynamodb = "0.30.0"
+aws-sdk-dynamodb = "1.3.0"
 modyne = { version = "0.2.1", path = "../..", features = ["derive"] }
 serde = { version = "1.0.158", features = ["derive"] }
 svix-ksuid = { version = "0.7.0", features = ["serde"] }
@@ -26,8 +26,8 @@ time = { version = "0.3.20", features = ["formatting", "parsing", "serde"] }
 tracing = "0.1.36"
 
 [dev-dependencies]
-aws-config = "0.56.1"
-aws-credential-types = "0.56.1"
+aws-config = "1.0.1"
+aws-credential-types = "1.0.1"
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
 tokio = { version = "1.0", features = ["macros"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/dynamodb-book/ch20-bigtimedeals/Cargo.toml
+++ b/dynamodb-book/ch20-bigtimedeals/Cargo.toml
@@ -18,7 +18,7 @@ once_cell = ["dep:once_cell", "modyne/once_cell"]
 
 [dependencies]
 aliri_braid = "0.4.0"
-aws-sdk-dynamodb = "0.30.0"
+aws-sdk-dynamodb = "1.3.0"
 futures = "0.3.27"
 modyne = { version = "0.2.1", path = "../..", features = ["derive"] }
 once_cell = { version = "1.17.2", optional = true }
@@ -30,8 +30,8 @@ time = { version = "0.3.20", features = ["formatting", "parsing", "serde"] }
 tracing = "0.1.36"
 
 [dev-dependencies]
-aws-config = "0.56.1"
-aws-credential-types = "0.56.1"
+aws-config = "1.0.1"
+aws-credential-types = "1.0.1"
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
 tokio = { version = "1.0", features = ["macros"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/dynamodb-book/ch20-bigtimedeals/Cargo.toml
+++ b/dynamodb-book/ch20-bigtimedeals/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/dynamodb-book-ch20-bigtimedeals"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
-rust-version = "1.67.0"
+rust-version = "1.68.0"
 
 [features]
 default = []

--- a/dynamodb-book/ch20-bigtimedeals/tests/localstack.rs
+++ b/dynamodb-book/ch20-bigtimedeals/tests/localstack.rs
@@ -11,7 +11,7 @@ use modyne::TestTableExt;
 async fn localstack_only_test() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     use futures::stream::TryStreamExt;
 
-    let config = aws_config::from_env()
+    let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
         .endpoint_url("http://localhost:4566")
         .credentials_provider(aws_credential_types::Credentials::new(
             "test", "test", None, None, "static",

--- a/dynamodb-book/ch21-github/Cargo.toml
+++ b/dynamodb-book/ch21-github/Cargo.toml
@@ -19,7 +19,7 @@ once_cell = ["modyne/once_cell"]
 
 [dependencies]
 aliri_braid = "0.4.0"
-aws-sdk-dynamodb = "0.30.0"
+aws-sdk-dynamodb = "1.3.0"
 castaway = "0.2.1"
 compact_str = { version = "0.7.0", features = ["serde"] }
 modyne = { version = "0.2.1", path = "../..", features = ["derive"] }
@@ -30,8 +30,8 @@ time = { version = "0.3.20", features = ["formatting", "parsing", "serde"] }
 tracing = "0.1.36"
 
 [dev-dependencies]
-aws-config = "0.56.1"
-aws-credential-types = "0.56.1"
+aws-config = "1.0.1"
+aws-credential-types = "1.0.1"
 test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
 tokio = { version = "1.0", features = ["macros"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/dynamodb-book/ch21-github/Cargo.toml
+++ b/dynamodb-book/ch21-github/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/dynamodb-book-ch21-github"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
-rust-version = "1.67.0"
+rust-version = "1.68.0"
 
 [features]
 default = []

--- a/modyne-derive/Cargo.toml
+++ b/modyne-derive/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["database","api-bindings"]
 documentation = "https://docs.rs/modyne-derive"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
-rust-version = "1.67.0"
+rust-version = "1.68.0"
 
 [lib]
 proc-macro = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub use modyne_derive::EntityDef;
 /// have the following attribute: `#[entity(MyEntity)]`
 #[cfg(feature = "derive")]
 pub use modyne_derive::Projection;
-use serde_dynamo::aws_sdk_dynamodb_0_30 as codec;
+use serde_dynamo::aws_sdk_dynamodb_1 as codec;
 
 pub use crate::error::Error;
 
@@ -919,22 +919,26 @@ where
             let hash = aws_sdk_dynamodb::types::AttributeDefinition::builder()
                 .set_attribute_name(Some(definition.hash_key().into()))
                 .set_attribute_type(Some(aws_sdk_dynamodb::types::ScalarAttributeType::S))
-                .build();
+                .build()
+                .expect("attribute name and attribute type are always provided");
             let mut key_schema = vec![aws_sdk_dynamodb::types::KeySchemaElement::builder()
                 .set_attribute_name(Some(definition.hash_key().into()))
                 .set_key_type(Some(aws_sdk_dynamodb::types::KeyType::Hash))
-                .build()];
+                .build()
+                .expect("attribute name and key type are always provided")];
             builder = builder.attribute_definitions(hash);
             if let Some(range_key) = definition.range_key() {
                 let range = aws_sdk_dynamodb::types::AttributeDefinition::builder()
                     .set_attribute_name(Some(range_key.into()))
                     .set_attribute_type(Some(aws_sdk_dynamodb::types::ScalarAttributeType::S))
-                    .build();
+                    .build()
+                    .expect("attribute name and attribute type are always provided");
                 key_schema.push(
                     aws_sdk_dynamodb::types::KeySchemaElement::builder()
                         .set_attribute_name(Some(range_key.into()))
                         .set_key_type(Some(aws_sdk_dynamodb::types::KeyType::Range))
-                        .build(),
+                        .build()
+                        .expect("attribute name and key type are always provided"),
                 );
                 builder = builder.attribute_definitions(range)
             }
@@ -946,7 +950,8 @@ where
                         .build(),
                 ))
                 .set_key_schema(Some(key_schema))
-                .build();
+                .build()
+                .expect("index name and key schema are always provided");
             builder = builder.global_secondary_indexes(gsi);
         }
 
@@ -955,22 +960,26 @@ where
         let hash = aws_sdk_dynamodb::types::AttributeDefinition::builder()
             .set_attribute_name(Some(primary_key_definition.hash_key.into()))
             .set_attribute_type(Some(aws_sdk_dynamodb::types::ScalarAttributeType::S))
-            .build();
+            .build()
+            .expect("attribute name and attribute type are always provided");
         let mut key_schema = vec![aws_sdk_dynamodb::types::KeySchemaElement::builder()
             .set_attribute_name(Some(primary_key_definition.hash_key.into()))
             .set_key_type(Some(aws_sdk_dynamodb::types::KeyType::Hash))
-            .build()];
+            .build()
+            .expect("attribute name and key type are always provided")];
         builder = builder.attribute_definitions(hash);
         if let Some(range_key) = primary_key_definition.range_key {
             let range = aws_sdk_dynamodb::types::AttributeDefinition::builder()
                 .set_attribute_name(Some(range_key.into()))
                 .set_attribute_type(Some(aws_sdk_dynamodb::types::ScalarAttributeType::S))
-                .build();
+                .build()
+                .expect("attribute name and attribute type are always provided");
             key_schema.push(
                 aws_sdk_dynamodb::types::KeySchemaElement::builder()
                     .set_attribute_name(Some(range_key.into()))
                     .set_key_type(Some(aws_sdk_dynamodb::types::KeyType::Range))
-                    .build(),
+                    .build()
+                    .expect("attribute name and key type are always provided"),
             );
             builder = builder.attribute_definitions(range)
         }

--- a/src/model.rs
+++ b/src/model.rs
@@ -173,6 +173,7 @@ impl GetTransact {
             )
             .table_name(table.table_name())
             .build()
+            .expect("key and table name are always provided")
     }
 }
 
@@ -435,7 +436,9 @@ impl PutTransact {
                 .set_expression_attribute_values(values)
         }
 
-        builder.build()
+        builder
+            .build()
+            .expect("item and table name are always provided")
     }
 }
 
@@ -783,7 +786,9 @@ impl UpdateTransact {
                 .set_expression_attribute_values(values)
         }
 
-        builder.build()
+        builder
+            .build()
+            .expect("key, update expression, and table name are always provided")
     }
 }
 
@@ -1048,7 +1053,9 @@ impl DeleteTransact {
                 .set_expression_attribute_values(values)
         }
 
-        builder.build()
+        builder
+            .build()
+            .expect("key and table name are always provided")
     }
 }
 
@@ -1123,6 +1130,7 @@ impl ConditionCheckTransact {
             )
             .set_table_name(Some(table.table_name().into()))
             .build()
+            .expect("key, condition expression, and table name are always provided")
     }
 }
 
@@ -1307,7 +1315,7 @@ impl TransactGet {
             .await;
 
         if let Ok(output) = &result {
-            let capacity = output.consumed_capacity().unwrap_or_default().iter().fold(
+            let capacity = output.consumed_capacity().iter().fold(
                 ConsumedCapacity::builder().build(),
                 |mut acc, next| {
                     acc.capacity_units = merge_values(acc.capacity_units, next.capacity_units);
@@ -1394,7 +1402,7 @@ impl TransactWrite {
             .await;
 
         if let Ok(output) = &result {
-            let capacity = output.consumed_capacity().unwrap_or_default().iter().fold(
+            let capacity = output.consumed_capacity().iter().fold(
                 ConsumedCapacity::builder().build(),
                 |mut acc, next| {
                     acc.capacity_units = merge_values(acc.capacity_units, next.capacity_units);
@@ -1428,14 +1436,16 @@ impl BatchWriteItem {
                 .put_request(
                     aws_sdk_dynamodb::types::PutRequest::builder()
                         .set_item(Some(op.item))
-                        .build(),
+                        .build()
+                        .expect("item is always provided"),
                 )
                 .build(),
             Self::DeleteItem(op) => aws_sdk_dynamodb::types::WriteRequest::builder()
                 .delete_request(
                     aws_sdk_dynamodb::types::DeleteRequest::builder()
                         .set_key(Some(op.key))
-                        .build(),
+                        .build()
+                        .expect("key is always provided"),
                 )
                 .build(),
         }
@@ -1502,9 +1512,12 @@ impl BatchGet {
             for item in self.operations {
                 kattr = kattr.keys(item.key);
             }
-            let tables = [(table.table_name().to_owned(), kattr.build())]
-                .into_iter()
-                .collect();
+            let tables = [(
+                table.table_name().to_owned(),
+                kattr.build().expect("keys is always provided"),
+            )]
+            .into_iter()
+            .collect();
             Some(tables)
         };
 
@@ -1518,7 +1531,7 @@ impl BatchGet {
             .await;
 
         if let Ok(output) = &result {
-            let capacity = output.consumed_capacity().unwrap_or_default().iter().fold(
+            let capacity = output.consumed_capacity().iter().fold(
                 ConsumedCapacity::builder().build(),
                 |mut acc, next| {
                     acc.capacity_units = merge_values(acc.capacity_units, next.capacity_units);
@@ -1598,7 +1611,7 @@ impl BatchWrite {
             .await;
 
         if let Ok(output) = &result {
-            let capacity = output.consumed_capacity().unwrap_or_default().iter().fold(
+            let capacity = output.consumed_capacity().iter().fold(
                 ConsumedCapacity::builder().build(),
                 |mut acc, next| {
                     acc.capacity_units = merge_values(acc.capacity_units, next.capacity_units);


### PR DESCRIPTION
Closes #13

This accomplishes the change without requiring any significant code changes in clients that aren't directly using the AWS SDK. As noted, there are very few changes to the DynamoDB Book examples. Primarily they just require updating to the relevant SDK crate versions, and things _just work_.

Also of note, `items` is no longer a hidden struct field, so we'll be able to remove that disclaimer.

Expects added to keep the API the same check to see what validations were being done in the relevant `.build()` functions, and ensuring that our internal use of those builders should _always_ satisfy their conditions, thus not requiring that the `BuildError`s be bubbled up, keeping the interface simple.

Related: awslabs/aws-sdk-rust#969, zenlist/serde_dynamo#96