### PR TITLE
feat: enable the use of non-standard entity type attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ The format of this changelog is based on [Keep a Changelog](https://keepachangel
 _Note_: Due to the updated MSRV of the AWS SDK, Modyne has updated its MSRV to 1.68.0
 
 - BREAKING: Updated the AWS SDK to 1.0 ([#13])
+- New: Added support for non-standard entity type attribute names and values ([#15])
 
 [#13](https://github.com/neoeinstein/modyne/issues/13)
+[#15](https://github.com/neoeinstein/modyne/issues/15)
 
 ## [0.2.1] - 2023-11-15
 

--- a/dynamodb-book/ch18-sessionstore/src/lib.rs
+++ b/dynamodb-book/ch18-sessionstore/src/lib.rs
@@ -26,6 +26,9 @@ impl App {
 }
 
 impl Table for App {
+    /// For demonstration, this example uses a non-standard entity type attribute name
+    const ENTITY_TYPE_ATTRIBUTE: &'static str = "et";
+
     type PrimaryKey = SessionToken;
     type IndexKeys = UsernameKey;
 

--- a/dynamodb-book/ch20-bigtimedeals/src/lib.rs
+++ b/dynamodb-book/ch20-bigtimedeals/src/lib.rs
@@ -85,7 +85,10 @@ impl App {
             .name("#brands", "brands")
             .value(":brands", StringSet(vec![&brand.brand_name]))
             .name("#entity_type", "entity_type")
-            .value(":entity_type", <Brands as modyne::EntityDef>::ENTITY_TYPE);
+            .value(
+                ":entity_type",
+                StringSet(vec![<Brands as modyne::EntityDef>::ENTITY_TYPE]),
+            );
         let update = Brands::update(()).expression(expression);
 
         TransactWrite::new()

--- a/src/error.rs
+++ b/src/error.rs
@@ -161,6 +161,9 @@ impl ItemDeserializationError {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-#[error("entity type is missing from item or is not a string")]
-pub(crate) struct MissingEntityTypeError {}
+/// An error indicating that the entity type is missing from a DynamoDB
+/// item, or could not be successfull extracted from the item
+#[derive(Debug, Default, thiserror::Error)]
+#[non_exhaustive]
+#[error("entity type is missing from item or could not be extracted")]
+pub struct MissingEntityTypeError {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -161,9 +161,15 @@ impl ItemDeserializationError {
     }
 }
 
-/// An error indicating that the entity type is missing from a DynamoDB
-/// item, or could not be successfull extracted from the item
-#[derive(Debug, Default, thiserror::Error)]
+/// An error retrieving the entity type for a DynamoDB item
+#[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
-#[error("entity type is missing from item or could not be extracted")]
-pub struct MissingEntityTypeError {}
+pub enum MissingEntityTypeError {
+    /// The entity type attribute was not found on the item
+    #[error("entity type attribute is missing from the item")]
+    AttributeNotFound,
+
+    /// The entity type attribute was found, but was malformed and could not be extracted
+    #[error("entity type attribute value is malformed and could not be extracted from the item")]
+    MalformedAttributeValue(#[source] Option<Box<dyn std::error::Error + Send + Sync>>),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -139,6 +139,7 @@ pub(crate) enum InnerError {
     TransactWriteItems(#[from] SdkError<TransactWriteItemsError>),
     ItemDeserialization(#[from] ItemDeserializationError),
     MissingEntityType(#[from] MissingEntityTypeError),
+    MalformedEntityType(#[from] MalformedEntityTypeError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -161,15 +162,20 @@ impl ItemDeserializationError {
     }
 }
 
-/// An error retrieving the entity type for a DynamoDB item
+/// The entity type attribute was not found on the item
+#[derive(Debug, thiserror::Error)]
+#[error("entity type attribute is missing from the item")]
+pub(crate) struct MissingEntityTypeError {}
+
+/// The entity type attribute was found, but was malformed and could not be extracted
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
-pub enum MissingEntityTypeError {
-    /// The entity type attribute was not found on the item
-    #[error("entity type attribute is missing from the item")]
-    AttributeNotFound,
+pub enum MalformedEntityTypeError {
+    /// The entity type attribute was expected to be a string value
+    #[error("expected the entity type attribute to be a string value")]
+    ExpectedStringValue,
 
-    /// The entity type attribute was found, but was malformed and could not be extracted
+    /// Custom error indicating why the entity type attribute was malformed
     #[error("entity type attribute value is malformed and could not be extracted from the item")]
-    MalformedAttributeValue(#[source] Option<Box<dyn std::error::Error + Send + Sync>>),
+    Custom(#[from] Box<dyn std::error::Error + Send + Sync>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,12 +69,14 @@ pub trait Table {
     /// In general, this function should not need to be overriden, but an override
     /// may be used in non-standard use cases, or for compatibility with
     /// existing systems.
+    #[inline]
     fn deserialize_entity_type(
         attr: &AttributeValue,
     ) -> Result<&EntityTypeNameRef, MalformedEntityTypeError> {
-        let value = attr
-            .as_s()
-            .map_err(|_| MalformedEntityTypeError::ExpectedStringValue)?;
+        let Ok(value) = attr.as_s() else {
+            return Err(MalformedEntityTypeError::ExpectedStringValue);
+        };
+
         Ok(EntityTypeNameRef::from_str(value.as_str()))
     }
 
@@ -83,6 +85,7 @@ pub trait Table {
     /// In general, this function should not need to be overriden, but an override
     /// may be used in non-standard use cases, or for compatibility with
     /// existing systems.
+    #[inline]
     fn serialize_entity_type(entity_type: &EntityTypeNameRef) -> AttributeValue {
         AttributeValue::S(entity_type.to_string())
     }


### PR DESCRIPTION
Allows overriding the default mechanism for extracting and embedding the entity type information in a DynamoDB item. This can support non-standard use cases. In most green-field applications, overriding the provided constant and methods should not be required, but there may be cases where working with an existing application where interoperability can be improved by allowing for explicit control over how the entity type is embedded or extracted.

This change is not a breaking change, and instead makes changes such that users who don't care about this more advanced use case are not required to make any updates.

cc: @happylinks

Closes #8