### PR TITLE
fix(MSRV): bump minimum Rust version to 1.71

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,11 +70,11 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.68
+      - uses: dtolnay/rust-toolchain@1.71
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
-      - run: cargo nextest run --workspace --no-fail-fast --features derive,once_cell --run-ignored all
-      - run: cargo test --workspace --doc --no-fail-fast --features derive,once_cell
+      - run: cargo nextest run --workspace --no-fail-fast --features derive --run-ignored all
+      - run: cargo test --workspace --doc --no-fail-fast --features derive
 
   test:
     name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.68.0"
+rust-version = "1.71.0"
 include = [
     "/docs",
     "/src",
@@ -24,7 +24,7 @@ include = [
 [features]
 default = []
 derive = ["dep:modyne-derive"]
-once_cell = ["dep:once_cell"]
+once_cell = []
 
 [dependencies]
 aliri_braid = "0.4.0"
@@ -33,7 +33,6 @@ aws-config = "1.0.1"
 aws-sdk-dynamodb = "1.3.0"
 fnv = "1.0.7"
 modyne-derive = { version = "=0.3.0", optional = true, path = "./modyne-derive" }
-once_cell = { version = "1.17.2", optional = true }
 serde = { version = "1.0.158", features = ["derive"] }
 serde_dynamo = { version = "4.2.13", features = ["aws-sdk-dynamodb+1"] }
 thiserror = "1.0.38"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ _An opinionated library for interacting with AWS DynamoDB single-table designs._
 [![docs.rs](https://img.shields.io/docsrs/modyne)][docsrs]
 [![crates.io](https://img.shields.io/crates/v/modyne)][cratesio]
 ![MIT/Apache-2.0 dual licensed](https://img.shields.io/crates/l/modyne)
-![modyne: rustc 1.70+](https://img.shields.io/badge/modyne-rustc_1.70+-lightgray.svg)†
+![modyne: rustc 1.71+](https://img.shields.io/badge/modyne-rustc_1.71+-lightgray.svg)
 
 ## Motive
 
@@ -53,9 +53,6 @@ For a more complete tour of the functionality in this crate, see the
 [documentation on docs.rs][docsrs].
 
 ---
-
-†: The MSRV for this crate can be lowered to 1.68.0 by enabling the
-`once_cell` feature.
 
 [cratesio]: https://crates.io/crates/modyne
 [docsrs]: https://docs.rs/modyne

--- a/docs/modyne.md
+++ b/docs/modyne.md
@@ -464,11 +464,7 @@ overrides to use a non-standard value codec with a non-standard attribute name.
 # Features
 
 - `derive`: Re-exports the derive macros provided by the `modyne-derive` crate.
-- `once_cell`: Uses the lazy initialization primitives provided by the
-  `once_cell` crate.
 
 # Minimum supported Rust version (MSRV)
 
-The minimum supported Rust version for this crate is 1.70.0. The MSRV can be
-reduced to 1.68.0 by enabling the `once_cell` feature to use that crate's lazy
-initialization primitives if desired.
+The minimum supported Rust version for this crate is 1.71.0.

--- a/dynamodb-book/ch18-sessionstore/Cargo.toml
+++ b/dynamodb-book/ch18-sessionstore/Cargo.toml
@@ -10,11 +10,11 @@ documentation = "https://docs.rs/dynamodb-book-ch18-sessionstore"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
-rust-version = "1.68.0"
+rust-version = "1.71.0"
 
 [features]
 default = []
-once_cell = ["modyne/once_cell"]
+once_cell = []
 
 [dependencies]
 aliri_braid = "0.4.0"

--- a/dynamodb-book/ch19-ecomm/Cargo.toml
+++ b/dynamodb-book/ch19-ecomm/Cargo.toml
@@ -10,11 +10,11 @@ documentation = "https://docs.rs/dynamodb-book-ch19-ecomm"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
-rust-version = "1.68.0"
+rust-version = "1.71.0"
 
 [features]
 default = []
-once_cell = ["modyne/once_cell"]
+once_cell = []
 
 [dependencies]
 aliri_braid = "0.4.0"

--- a/dynamodb-book/ch20-bigtimedeals/Cargo.toml
+++ b/dynamodb-book/ch20-bigtimedeals/Cargo.toml
@@ -10,18 +10,17 @@ documentation = "https://docs.rs/dynamodb-book-ch20-bigtimedeals"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
-rust-version = "1.68.0"
+rust-version = "1.71.0"
 
 [features]
 default = []
-once_cell = ["dep:once_cell", "modyne/once_cell"]
+once_cell = []
 
 [dependencies]
 aliri_braid = "0.4.0"
 aws-sdk-dynamodb = "1.3.0"
 futures = "0.3.27"
 modyne = { version = "0.3.0", path = "../..", features = ["derive"] }
-once_cell = { version = "1.17.2", optional = true }
 pin-project-lite = "0.2.9"
 serde = { version = "1.0.158", features = ["derive"] }
 serde_dynamo = "4.2.3"

--- a/dynamodb-book/ch20-bigtimedeals/src/lib.rs
+++ b/dynamodb-book/ch20-bigtimedeals/src/lib.rs
@@ -1218,13 +1218,8 @@ impl QueryInput for CategoryDealsByDateQuery<'_> {
 }
 
 fn format_as_date(time: time::Date) -> String {
-    #[cfg(not(feature = "once_cell"))]
     static FORMAT: std::sync::OnceLock<Vec<time::format_description::FormatItem<'static>>> =
         std::sync::OnceLock::new();
-
-    #[cfg(feature = "once_cell")]
-    static FORMAT: once_cell::sync::OnceCell<Vec<time::format_description::FormatItem<'static>>> =
-        once_cell::sync::OnceCell::new();
 
     let format = FORMAT.get_or_init(|| {
         time::format_description::parse_borrowed::<2>("[year]-[month]-[day]").unwrap()

--- a/dynamodb-book/ch21-github/Cargo.toml
+++ b/dynamodb-book/ch21-github/Cargo.toml
@@ -11,11 +11,11 @@ documentation = "https://docs.rs/dynamodb-book-ch21-github"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
-rust-version = "1.68.0"
+rust-version = "1.71.0"
 
 [features]
 default = []
-once_cell = ["modyne/once_cell"]
+once_cell = []
 
 [dependencies]
 aliri_braid = "0.4.0"

--- a/modyne-derive/Cargo.toml
+++ b/modyne-derive/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["database","api-bindings"]
 documentation = "https://docs.rs/modyne-derive"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
-rust-version = "1.68.0"
+rust-version = "1.71.0"
 
 [lib]
 proc-macro = true

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -557,13 +557,8 @@ impl Projection {
     }
 
     fn reserved_words() -> &'static FnvHashSet<&'static [u8]> {
-        #[cfg(not(feature = "once_cell"))]
         static RESERVED_WORDS_SET: std::sync::OnceLock<FnvHashSet<&'static [u8]>> =
             std::sync::OnceLock::new();
-
-        #[cfg(feature = "once_cell")]
-        static RESERVED_WORDS_SET: once_cell::sync::OnceCell<FnvHashSet<&'static [u8]>> =
-            once_cell::sync::OnceCell::new();
 
         RESERVED_WORDS_SET.get_or_init(|| {
             Self::RESERVED_WORDS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -919,11 +919,7 @@ struct FullEntity<T: Entity> {
 
 #[doc(hidden)]
 pub mod __private {
-    #[cfg(not(feature = "once_cell"))]
     pub type OnceLock<T> = std::sync::OnceLock<T>;
-
-    #[cfg(feature = "once_cell")]
-    pub type OnceLock<T> = once_cell::sync::OnceCell<T>;
 
     pub fn get_entity_type<P: crate::Projection>(
         item: &crate::Item,


### PR DESCRIPTION
Additionally makes the `once_cell` crate feature a no-op, to be removed in a future version.