### PR TITLE
fix(MSRV): bump minimum Rust version to 1.74

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,7 +70,7 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.71
+      - uses: dtolnay/rust-toolchain@1.74
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       - run: cargo nextest run --workspace --no-fail-fast --features derive --run-ignored all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.71.0"
+rust-version = "1.74.0"
 include = [
     "/docs",
     "/src",

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ _An opinionated library for interacting with AWS DynamoDB single-table designs._
 [![docs.rs](https://img.shields.io/docsrs/modyne)][docsrs]
 [![crates.io](https://img.shields.io/crates/v/modyne)][cratesio]
 ![MIT/Apache-2.0 dual licensed](https://img.shields.io/crates/l/modyne)
-![modyne: rustc 1.71+](https://img.shields.io/badge/modyne-rustc_1.71+-lightgray.svg)
+![modyne: rustc 1.74+](https://img.shields.io/badge/modyne-rustc_1.74+-lightgray.svg)
 
 ## Motive
 

--- a/docs/modyne.md
+++ b/docs/modyne.md
@@ -467,4 +467,4 @@ overrides to use a non-standard value codec with a non-standard attribute name.
 
 # Minimum supported Rust version (MSRV)
 
-The minimum supported Rust version for this crate is 1.71.0.
+The minimum supported Rust version for this crate is 1.74.0.

--- a/dynamodb-book/ch18-sessionstore/Cargo.toml
+++ b/dynamodb-book/ch18-sessionstore/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/dynamodb-book-ch18-sessionstore"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
-rust-version = "1.71.0"
+rust-version = "1.74.0"
 
 [features]
 default = []

--- a/dynamodb-book/ch19-ecomm/Cargo.toml
+++ b/dynamodb-book/ch19-ecomm/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/dynamodb-book-ch19-ecomm"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
-rust-version = "1.71.0"
+rust-version = "1.74.0"
 
 [features]
 default = []

--- a/dynamodb-book/ch20-bigtimedeals/Cargo.toml
+++ b/dynamodb-book/ch20-bigtimedeals/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/dynamodb-book-ch20-bigtimedeals"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
-rust-version = "1.71.0"
+rust-version = "1.74.0"
 
 [features]
 default = []

--- a/dynamodb-book/ch21-github/Cargo.toml
+++ b/dynamodb-book/ch21-github/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/dynamodb-book-ch21-github"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
-rust-version = "1.71.0"
+rust-version = "1.74.0"
 
 [features]
 default = []

--- a/modyne-derive/Cargo.toml
+++ b/modyne-derive/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["database","api-bindings"]
 documentation = "https://docs.rs/modyne-derive"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
-rust-version = "1.71.0"
+rust-version = "1.74.0"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
AWS SDK compatibility requires a newer minimum Rust version