### PR TITLE
Add feature flags to allow selection of AWS transitive deps

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,7 +72,7 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@1.88
+      - uses: dtolnay/rust-toolchain@1.91
       - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
       - uses: taiki-e/install-action@650c5ca14212efbbf3e580844b04bdccf68dac31 # v2.67.18
         with:

--- a/deny.toml
+++ b/deny.toml
@@ -110,9 +110,11 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow
-    # list
-    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+    # aws-lc-fips-sys ships AWS-LC's FIPS-validated build, which retains
+    # OpenSSL-licensed code from BoringSSL/OpenSSL ancestry. The license is
+    # unavoidable for any FIPS-capable TLS path and is only pulled in when
+    # the `rustls-aws-lc-fips` feature is enabled.
+    { allow = ["OpenSSL"], name = "aws-lc-fips-sys", version = "*" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,

--- a/dynamodb-book/ch18-sessionstore/Cargo.toml
+++ b/dynamodb-book/ch18-sessionstore/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/dynamodb-book-ch18-sessionstore"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
-rust-version = "1.75.0"
+rust-version = "1.91.0"
 
 [features]
 default = []
@@ -18,7 +18,7 @@ once_cell = []
 
 [dependencies]
 aliri_braid = "0.4.0"
-aws-sdk-dynamodb = "1.3.0"
+aws-sdk-dynamodb = { version = "1.3.0", default-features = false, features = ["rt-tokio", "default-https-client"] }
 modyne = { version = "0.3.0", path = "../../modyne", features = ["derive"] }
 serde = { version = "1.0.158", features = ["derive"] }
 time = { version = "0.3.20", features = ["formatting", "parsing", "serde"] }
@@ -27,7 +27,7 @@ tracing = "0.1.36"
 uuid = { version = "1.3.0", features = ["v4", "serde"] }
 
 [dev-dependencies]
-aws-config = "1.2.1"
+aws-config = { version = "1.2.1", default-features = false, features = ["rt-tokio", "default-https-client"] }
 aws-credential-types = "1.2.0"
 test-log = { version = "0.2.16", default-features = false, features = ["trace"] }
 tokio = { version = "1.37", features = ["macros"] }

--- a/dynamodb-book/ch19-ecomm/Cargo.toml
+++ b/dynamodb-book/ch19-ecomm/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/dynamodb-book-ch19-ecomm"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
-rust-version = "1.75.0"
+rust-version = "1.91.0"
 
 [features]
 default = []
@@ -18,7 +18,7 @@ once_cell = []
 
 [dependencies]
 aliri_braid = "0.4.0"
-aws-sdk-dynamodb = "1.3.0"
+aws-sdk-dynamodb = { version = "1.3.0", default-features = false, features = ["rt-tokio", "default-https-client"] }
 modyne = { version = "0.3.0", path = "../../modyne", features = ["derive"] }
 serde = { version = "1.0.158", features = ["derive"] }
 svix-ksuid = { version = "0.8.0", features = ["serde"] }
@@ -26,7 +26,7 @@ time = { version = "0.3.20", features = ["formatting", "parsing", "serde"] }
 tracing = "0.1.36"
 
 [dev-dependencies]
-aws-config = "1.2.1"
+aws-config = { version = "1.2.1", default-features = false, features = ["rt-tokio", "default-https-client"] }
 aws-credential-types = "1.2.0"
 test-log = { version = "0.2.16", default-features = false, features = ["trace"] }
 tokio = { version = "1.37", features = ["macros"] }

--- a/dynamodb-book/ch20-bigtimedeals/Cargo.toml
+++ b/dynamodb-book/ch20-bigtimedeals/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/dynamodb-book-ch20-bigtimedeals"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
-rust-version = "1.75.0"
+rust-version = "1.91.0"
 
 [features]
 default = []
@@ -18,7 +18,7 @@ once_cell = []
 
 [dependencies]
 aliri_braid = "0.4.0"
-aws-sdk-dynamodb = "1.3.0"
+aws-sdk-dynamodb = { version = "1.3.0", default-features = false, features = ["rt-tokio", "default-https-client"] }
 futures = "0.3.27"
 modyne = { version = "0.3.0", path = "../../modyne", features = ["derive"] }
 pin-project-lite = "0.2.9"
@@ -29,7 +29,7 @@ time = { version = "0.3.20", features = ["formatting", "parsing", "serde"] }
 tracing = "0.1.36"
 
 [dev-dependencies]
-aws-config = "1.2.1"
+aws-config = { version = "1.2.1", default-features = false, features = ["rt-tokio", "default-https-client"] }
 aws-credential-types = "1.2.0"
 test-log = { version = "0.2.16", default-features = false, features = ["trace"] }
 tokio = { version = "1.37", features = ["macros"] }

--- a/dynamodb-book/ch20-bigtimedeals/src/lib.rs
+++ b/dynamodb-book/ch20-bigtimedeals/src/lib.rs
@@ -14,7 +14,6 @@ use modyne::{
 };
 use serde_dynamo::string_set::StringSet;
 use svix_ksuid::{Ksuid, KsuidLike};
-use time::format_description::well_known::Rfc3339;
 
 #[derive(Clone, Debug)]
 pub struct App {
@@ -1184,7 +1183,7 @@ impl QueryInput for BrandDealsByDateQuery<'_> {
     type Aggregate = Vec<Deal>;
 
     fn key_condition(&self) -> expr::KeyCondition<Self::Index> {
-        let date = self.date.format(&Rfc3339).unwrap();
+        let date = self.date;
         let partition = format!("BRAND#{}#{date}", self.brand).to_ascii_uppercase();
         let bound = self
             .last_seen
@@ -1208,7 +1207,7 @@ impl QueryInput for CategoryDealsByDateQuery<'_> {
     type Aggregate = Vec<Deal>;
 
     fn key_condition(&self) -> expr::KeyCondition<Self::Index> {
-        let date = self.date.format(&Rfc3339).unwrap();
+        let date = self.date;
         let partition = format!("CATEGORY#{}#{date}", self.category).to_ascii_uppercase();
         let bound = self
             .last_seen

--- a/dynamodb-book/ch21-github/Cargo.toml
+++ b/dynamodb-book/ch21-github/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/dynamodb-book-ch21-github"
 homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
-rust-version = "1.75.0"
+rust-version = "1.91.0"
 
 [features]
 default = []
@@ -19,7 +19,7 @@ once_cell = []
 
 [dependencies]
 aliri_braid = "0.4.0"
-aws-sdk-dynamodb = "1.3.0"
+aws-sdk-dynamodb = { version = "1.3.0", default-features = false, features = ["rt-tokio", "default-https-client"] }
 castaway = "0.2.2"
 compact_str = { version = "0.9.0", features = ["serde"] }
 modyne = { version = "0.3.0", path = "../../modyne", features = ["derive"] }
@@ -30,7 +30,7 @@ time = { version = "0.3.20", features = ["formatting", "parsing", "serde"] }
 tracing = "0.1.36"
 
 [dev-dependencies]
-aws-config = "1.2.1"
+aws-config = { version = "1.2.1", default-features = false, features = ["rt-tokio", "default-https-client"] }
 aws-credential-types = "1.2.0"
 test-log = { version = "0.2.16", default-features = false, features = ["trace"] }
 tokio = { version = "1.37", features = ["macros"] }

--- a/modyne/CHANGELOG.md
+++ b/modyne/CHANGELOG.md
@@ -4,6 +4,18 @@ The format of this changelog is based on [Keep a Changelog](https://keepachangel
 
 ## [Unreleased]
 
+_Note_: Following the updated MSRV of the AWS SDK, Modyne has updated its MSRV to 1.91.0
+
+- New: Added feature flags to select the AWS SDK runtime/HTTP stack
+  (`rt-tokio`, `default-https-client`) and the TLS/crypto provider
+  (`rustls-aws-lc`, `rustls-aws-lc-fips`, `rustls-ring`, `s2n-tls`)
+  independently. The defaults preserve the previous behavior
+  (Tokio + hyper 1.x + rustls + aws-lc-rs).
+- BREAKING: `aws-sdk-dynamodb` is now pulled in with `default-features = false`.
+  Consumers relying on the SDK's `behavior-version-latest` or other non-default
+  features must enable them explicitly.
+- Cleanup: Removed the unused `aws-config` dependency.
+
 ## [0.3.0] - 2023-12-07
 
 _Note_: Due to the updated MSRV of the AWS SDK, Modyne has updated its MSRV to 1.68.0

--- a/modyne/Cargo.toml
+++ b/modyne/Cargo.toml
@@ -14,15 +14,31 @@ edition = "2021"
 rust-version = "1.75.0"
 
 [features]
-default = []
+default = ["rt-tokio", "default-https-client", "rustls-aws-lc"]
 derive = ["dep:modyne-derive"]
 once_cell = []
+
+# AWS SDK runtime / HTTP-stack flags. These mirror the upstream
+# `aws-sdk-dynamodb` feature names.
+rt-tokio = ["aws-sdk-dynamodb/rt-tokio"]
+# Provides the SDK's default HTTPS client (hyper 1.x). Disable to bring
+# your own HTTP client via `SdkConfig::http_client(...)`.
+default-https-client = ["aws-sdk-dynamodb/default-https-client"]
+
+# TLS / crypto providers, selected independently of the HTTP-stack flags
+# via `aws-smithy-http-client`. Multiple providers can be enabled
+# simultaneously; the choice is then made at runtime when constructing
+# the HTTPS connector.
+rustls-aws-lc = ["dep:aws-smithy-http-client", "aws-smithy-http-client/rustls-aws-lc"]
+rustls-aws-lc-fips = ["dep:aws-smithy-http-client", "aws-smithy-http-client/rustls-aws-lc-fips"]
+rustls-ring = ["dep:aws-smithy-http-client", "aws-smithy-http-client/rustls-ring"]
+s2n-tls = ["dep:aws-smithy-http-client", "aws-smithy-http-client/s2n-tls"]
 
 [dependencies]
 aliri_braid = "0.4.0"
 async-trait = "0.1.66"
-aws-config = "1.0.1"
-aws-sdk-dynamodb = "1.3.0"
+aws-sdk-dynamodb = { version = "1.3.0", default-features = false }
+aws-smithy-http-client = { version = "1.1.12", default-features = false, optional = true }
 fnv = "1.0.7"
 modyne-derive = { version = "0.3", optional = true, path = "../modyne-derive" }
 serde = { version = "1.0.158", features = ["derive"] }
@@ -41,4 +57,4 @@ tracing = "0.1.36"
 modyne-derive = { version = "=0.3.0", path = "../modyne-derive" }
 
 [package.metadata.docs.rs]
-features = ["derive"]
+features = ["derive", "rustls-aws-lc"]

--- a/modyne/Cargo.toml
+++ b/modyne/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/neoeinstein/modyne"
 repository = "https://github.com/neoeinstein/modyne"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.91.0"
 
 [features]
 default = ["rt-tokio", "default-https-client", "rustls-aws-lc"]


### PR DESCRIPTION
This adds feature flags to allow the user to select which AWS transitive dependencies they want to use - specifically which HTTP client, and which crypto implementation.